### PR TITLE
Fix character name issues (creating and approving)

### DIFF
--- a/Uchu.Char/Handlers/CharacterHandler.cs
+++ b/Uchu.Char/Handlers/CharacterHandler.cs
@@ -111,7 +111,7 @@ namespace Uchu.Char.Handlers
 
             await using (var ctx = new UchuContext())
             {
-                if (ctx.Characters.Any(c => c.Name == packet.CharacterName))
+                if (ctx.Characters.Any(c => c.Name == packet.CharacterName || c.CustomName == packet.CharacterName))
                 {
                     Logger.Debug($"{connection} character create rejected due to duplicate name");
                     connection.Send(new CharacterCreateResponse
@@ -121,7 +121,7 @@ namespace Uchu.Char.Handlers
                     return;
                 }
 
-                if (ctx.Characters.Any(c => c.Name == name))
+                if (ctx.Characters.Any(c => c.Name == name || c.CustomName == name))
                 {
                     Logger.Debug($"{connection} character create rejected due to duplicate pre-made name");
                     connection.Send(new CharacterCreateResponse

--- a/Uchu.Core/Handlers/Commands/StandardCommandHandler.cs
+++ b/Uchu.Core/Handlers/Commands/StandardCommandHandler.cs
@@ -180,15 +180,15 @@ namespace Uchu.Core.Handlers.Commands
                     ResourceStrings.StandardCommandHandler_ApproveUsername_ArgumentsNullException);
             
             await using var ctx = new UchuContext();
-            if (arguments.Length == 0 || arguments[0].ToLower() == "all")
+            if (arguments.Length == 0 || arguments[0].ToLower() == "*" || arguments[0] == "")
             {
                 var unApproved = ctx.Characters.Where(c => !c.NameRejected && c.Name != c.CustomName && !string.IsNullOrEmpty(c.CustomName));
 
-                if (arguments.Length != 1 || arguments[0] != "all")
+                if (arguments.Length != 1 || arguments[0] != "*")
                 {
                     return string.Join("\n",
-                               unApproved.Select(s => s.CustomName)
-                           ) + "\napprove <name> / all";
+                                unApproved.Select(s => s.CustomName)
+                            ) + "\napprove <name> / *";
                 }
 
                 foreach (var character in unApproved)
@@ -203,7 +203,7 @@ namespace Uchu.Core.Handlers.Commands
             }
 
             var selectedCharacter = await ctx.Characters.FirstOrDefaultAsync(
-                c => c.CustomName == arguments[1] && !c.NameRejected
+                c => c.CustomName == arguments[0] && !c.NameRejected
             ).ConfigureAwait(false);
 
             if (selectedCharacter == null)


### PR DESCRIPTION
Fixes #127, #128 and #129

- Added checks to prevent multiple characters with the same name from being created
- `/approve <name>` now works, no longer needs `<name>` as second argument
- `/approve all` renamed to `/approve *` (to make it possible to approve the custom name "all")
- `/approve` with extra space no longer sets someone's name to an empty string